### PR TITLE
Add commands to print Action and ActionResult data from text proto

### DIFF
--- a/src/main/java/com/google/devtools/build/remote/client/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/remote/client/AbstractRemoteActionCache.java
@@ -77,8 +77,7 @@ public abstract class AbstractRemoteActionCache {
    */
   private void addChildDirectories(Directory dir, List<Directory> directories) throws IOException {
     for (DirectoryNode childNode : dir.getDirectoriesList()) {
-      Directory childDir;
-      childDir = Directory.parseFrom(downloadBlob(childNode.getDigest()));
+      Directory childDir = Directory.parseFrom(downloadBlob(childNode.getDigest()));
       directories.add(childDir);
       addChildDirectories(childDir, directories);
     }

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClient.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClient.java
@@ -149,6 +149,9 @@ public class RemoteClient {
     listDirectory(path, tree.getRoot(), childrenMap, limit);
   }
 
+  // Escape an argument so that it can passed as a single argument in bash command line. Unless the
+  // argument contains no special characters, it will be wrapped in single quotes to escape special
+  // behaviour.
   private static String escapeBash(String arg) {
     final String s = arg.toString();
     if (s.isEmpty()) {
@@ -211,6 +214,13 @@ public class RemoteClient {
 
     System.out.println("\nOutput directories:");
     printList(action.getOutputDirectoriesList(), limit);
+
+    System.out.println("\nPlatform:");
+    if (action.getPlatform() != null && !action.getPlatform().getPropertiesList().isEmpty()) {
+      System.out.println(action.getPlatform().toString());
+    } else {
+      System.out.println("(none)");
+    }
   }
 
   public static void main(String[] args) throws Exception {

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClient.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClient.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /** A standalone client for interacting with remote caches in Bazel. */
 public class RemoteClient {
@@ -172,20 +173,26 @@ public class RemoteClient {
     }
   }
 
+  // Given an argument array, output the corresponding bash command to run the command with these
+  // arguments.
+  private static String getCommandLine(List<String> args) {
+    List<String> escapedArgs =
+        args.stream()
+            .map(arg -> escapeBash(arg))
+            .collect(Collectors.toList());
+    return SPACE_JOINER.join(escapedArgs);
+  }
+
   // Outputs a bash executable line that corresponds to executing the given command.
   private static void printCommand(Command command) {
-    List<String> escapedCommand = new ArrayList<>();
-
-    for (String arg : command.getArgumentsList()) {
-      escapedCommand.add(escapeBash(arg));
-    }
-
     for (EnvironmentVariable var : command.getEnvironmentVariablesList()) {
       System.out.printf("%s=%s \\\n", escapeBash(var.getName()), escapeBash(var.getValue()));
     }
     System.out.print("  ");
-    System.out.println(SPACE_JOINER.join(escapedCommand));
+
+    System.out.println(getCommandLine(command.getArgumentsList()));
   }
+
 
   private static void printList(List<String> list, int limit) {
     if (list.isEmpty()) {

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
@@ -37,7 +37,7 @@ public final class RemoteClientOptions {
   )
   public static class LsCommand {
     @Parameter(
-      names = { "--digest", "-d" },
+      names = {"--digest", "-d"},
       required = true,
       converter = DigestConverter.class,
       description = "The digest of the Directory to list in hex_hash/size_bytes."
@@ -45,7 +45,7 @@ public final class RemoteClientOptions {
     public Digest digest = null;
 
     @Parameter(
-      names = { "--limit", "-l" },
+      names = {"--limit", "-l"},
       description = "The maximum number of files in the Directory to list."
     )
     public int limit = 100;
@@ -57,7 +57,7 @@ public final class RemoteClientOptions {
   )
   public static class LsOutDirCommand {
     @Parameter(
-      names = { "--digest", "-d" },
+      names = {"--digest", "-d"},
       required = true,
       converter = DigestConverter.class,
       description = "The digest of the OutputDirectory to list in hex_hash/size_bytes."
@@ -65,7 +65,7 @@ public final class RemoteClientOptions {
     public Digest digest = null;
 
     @Parameter(
-      names = { "--limit", "-l" },
+      names = {"--limit", "-l"},
       description = "The maximum number of files in the OutputDirectory to list."
     )
     public int limit = 100;
@@ -77,7 +77,7 @@ public final class RemoteClientOptions {
   )
   public static class GetDirCommand {
     @Parameter(
-      names = { "--digest", "-d" },
+      names = {"--digest", "-d"},
       required = true,
       converter = DigestConverter.class,
       description = "The digest of the Directory to download in hex_hash/size_bytes."
@@ -85,7 +85,7 @@ public final class RemoteClientOptions {
     public Digest digest = null;
 
     @Parameter(
-      names = { "--path", "-o" },
+      names = {"--path", "-o"},
       converter = PathConverter.class,
       description = "The local path to download the Directory contents into."
     )
@@ -98,7 +98,7 @@ public final class RemoteClientOptions {
   )
   public static class GetOutDirCommand {
     @Parameter(
-      names = { "--digest", "-d" },
+      names = {"--digest", "-d"},
       required = true,
       converter = DigestConverter.class,
       description = "The digest of the OutputDirectory to download in hex_hash/size_bytes."
@@ -106,7 +106,7 @@ public final class RemoteClientOptions {
     public Digest digest = null;
 
     @Parameter(
-      names = { "--path", "-o" },
+      names = {"--path", "-o"},
       converter = PathConverter.class,
       description = "The local path to download the OutputDirectory contents into."
     )
@@ -121,7 +121,7 @@ public final class RemoteClientOptions {
   )
   public static class CatCommand {
     @Parameter(
-      names = { "--digest", "-d" },
+      names = {"--digest", "-d"},
       required = true,
       converter = DigestConverter.class,
       description = "The digest in the format hex_hash/size_bytes of the blob to download."
@@ -129,7 +129,7 @@ public final class RemoteClientOptions {
     public Digest digest = null;
 
     @Parameter(
-      names = { "--file", "-o" },
+      names = {"--file", "-o"},
       converter = FileConverter.class,
       description = "Specifies a file to write the blob contents to instead of stdout."
     )
@@ -137,39 +137,47 @@ public final class RemoteClientOptions {
   }
 
   @Parameters(
-      commandDescription = "Parse and display an Action proto.",
-      separators = "="
+    commandDescription = "Parse and display an Action with its corresponding command.",
+    separators = "="
   )
   public static class ShowActionCommand {
     @Parameter(
-        names = "--textproto",
-        required = true,
-        converter = FileConverter.class,
-        description = "Path to a Action proto stored in protobuf text format."
+      names = {"--textproto", "-p"},
+      required = true,
+      converter = FileConverter.class,
+      description = "Path to a Action proto stored in protobuf text format."
     )
     public File file = null;
 
     @Parameter(
-        names = "--limit",
-        description = "The maximum number of input/output files to list."
+      names = {"--limit", "-l"},
+      description = "The maximum number of input/output files to list."
     )
     public int limit = 100;
   }
 
+  @Parameters(commandDescription = "Parse and display an ActionResult.", separators = "=")
   public static class ShowActionResultCommand {
     @Parameter(
-        names = "--textproto",
-        required = true,
-        converter = FileConverter.class,
-        description = "Path to a Action proto stored in protobuf text format."
+      names = {"--textproto", "-p"},
+      required = true,
+      converter = FileConverter.class,
+      description = "Path to a ActionResult proto stored in protobuf text format."
     )
     public File file = null;
 
     @Parameter(
-        names = "--limit",
-        description = "The maximum number of input/output files to list."
+      names = {"--limit", "-l"},
+      description = "The maximum number of output files to list."
     )
     public int limit = 100;
+
+    @Parameter(
+      names = {"--show_raw_output", "-r"},
+      description =
+          "Print OutputFile contents if they were returned as raw bytes in the given ActionResult."
+    )
+    public boolean showRawOutputs = false;
   }
 
   /** Converter for hex_hash/size_bytes string to a Digest object. */

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
@@ -136,6 +136,26 @@ public final class RemoteClientOptions {
     public File file = null;
   }
 
+  @Parameters(
+      commandDescription = "Parse and display an Action proto.",
+      separators = "="
+  )
+  public static class ShowActionCommand {
+    @Parameter(
+        names = "--textproto",
+        required = true,
+        converter = FileConverter.class,
+        description = "Path to a Action proto stored in protobuf text format."
+    )
+    public File file = null;
+
+    @Parameter(
+        names = "--limit",
+        description = "The maximum number of input/output files to list."
+    )
+    public int limit = 100;
+  }
+
   /** Converter for hex_hash/size_bytes string to a Digest object. */
   public static class DigestConverter implements IStringConverter<Digest> {
     @Override

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
@@ -156,6 +156,22 @@ public final class RemoteClientOptions {
     public int limit = 100;
   }
 
+  public static class ShowActionResultCommand {
+    @Parameter(
+        names = "--textproto",
+        required = true,
+        converter = FileConverter.class,
+        description = "Path to a Action proto stored in protobuf text format."
+    )
+    public File file = null;
+
+    @Parameter(
+        names = "--limit",
+        description = "The maximum number of input/output files to list."
+    )
+    public int limit = 100;
+  }
+
   /** Converter for hex_hash/size_bytes string to a Digest object. */
   public static class DigestConverter implements IStringConverter<Digest> {
     @Override

--- a/src/main/java/com/google/devtools/build/remote/client/ShellEscaper.java
+++ b/src/main/java/com/google/devtools/build/remote/client/ShellEscaper.java
@@ -1,0 +1,77 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.remote.client;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
+import com.google.common.escape.CharEscaperBuilder;
+import com.google.common.escape.Escaper;
+import java.util.List;
+
+/**
+ * Utility class to escape strings for use with shell commands.
+ *
+ * <p>The code for this class was based on
+ * src/main/java/com/google/devtools/build/lib/util/ShellEscaper.java from the Bazel codebase.
+ *
+ * <p>Escaped strings may safely be inserted into shell commands. Escaping is only done if
+ * necessary. Strings containing only shell-neutral characters will not be escaped.
+ */
+public class ShellEscaper extends Escaper {
+  public static final ShellEscaper INSTANCE = new ShellEscaper();
+
+  private static final Function<String, String> AS_FUNCTION = INSTANCE.asFunction();
+
+  private static final Joiner SPACE_JOINER = Joiner.on(' ');
+  private static final Escaper STRONGQUOTE_ESCAPER =
+      new CharEscaperBuilder().addEscape('\'', "'\\''").toEscaper();
+  private static final CharMatcher SAFECHAR_MATCHER =
+      CharMatcher.anyOf("@%-_+:,./")
+          .or(CharMatcher.inRange('0', '9')) // We can't use CharMatcher.javaLetterOrDigit(),
+          .or(CharMatcher.inRange('a', 'z')) // that would also accept non-ASCII digits and
+          .or(CharMatcher.inRange('A', 'Z')) // letters.
+          .precomputed();
+
+  /**
+   * Escape an argument so that it can passed as a single argument in bash command line. Unless the
+   * argument contains no special characters, it will be wrapped in single quotes to escape special
+   * behaviour. In the case that the arguments itself has single quotes, the inner single quotes are
+   * escaped as a special case to avoid conflicting with the out single quotes.
+   */
+  public String escape(String unescaped) {
+    final String s = unescaped.toString();
+    if (s.isEmpty()) {
+      // Empty string is a special case: needs to be quoted to ensure that it
+      // gets treated as a separate argument.
+      return "''";
+    } else {
+      return SAFECHAR_MATCHER.matchesAllOf(s) ? s : "'" + STRONGQUOTE_ESCAPER.escape(s) + "'";
+    }
+  }
+
+  public static String escapeString(String unescaped) {
+    return INSTANCE.escape(unescaped);
+  }
+
+  /**
+   * Returns a string containing the argument strings in the given list escaped and joined by
+   * spaces.
+   */
+  public static String escapeJoinAll(List<String> args) {
+    return SPACE_JOINER.join(Iterables.transform(args, AS_FUNCTION));
+  }
+}

--- a/src/test/java/com/google/devtools/build/remote/client/BUILD
+++ b/src/test/java/com/google/devtools/build/remote/client/BUILD
@@ -1,6 +1,9 @@
 java_test(
     name = "GrpcRemoteCacheTest",
-    srcs = glob(["*.java"]),
+    srcs = [
+        "FakeImmutableCacheByteStreamImpl.java",
+        "GrpcRemoteCacheTest.java",
+    ],
     deps = [
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/http_client:google_http_client",
@@ -17,5 +20,14 @@ java_test(
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_grpc",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_proto",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_proto",
+    ],
+)
+
+java_test(
+    name = "ShellEscaperTest",
+    srcs = ["ShellEscaperTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/remote/client",
+        "//3rdparty/jvm/com/google/truth",
     ],
 )

--- a/src/test/java/com/google/devtools/build/remote/client/ShellEscaperTest.java
+++ b/src/test/java/com/google/devtools/build/remote/client/ShellEscaperTest.java
@@ -1,0 +1,47 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.remote.client;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.remote.client.ShellEscaper.escapeString;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ShellEscaper}. */
+@RunWith(JUnit4.class)
+public class ShellEscaperTest {
+
+  @Test
+  public void shellEscape() throws Exception {
+    assertThat(escapeString("")).isEqualTo("''");
+    assertThat(escapeString("foo")).isEqualTo("foo");
+    assertThat(escapeString("foo bar")).isEqualTo("'foo bar'");
+    assertThat(escapeString("'foo'")).isEqualTo("''\\''foo'\\'''");
+    assertThat(escapeString("\\'foo\\'")).isEqualTo("'\\'\\''foo\\'\\'''");
+    assertThat(escapeString("${filename%.c}.o")).isEqualTo("'${filename%.c}.o'");
+    assertThat(escapeString("<html!>")).isEqualTo("'<html!>'");
+  }
+
+  @Test
+  public void escapeJoinAll() throws Exception {
+    String actual =
+        ShellEscaper.escapeJoinAll(
+            Arrays.asList("foo", "@echo:-", "100", "$US", "a b", "\"qu'ot'es\"", "\"quot\"", "\\"));
+    assertThat(actual)
+        .isEqualTo("foo @echo:- 100 '$US' 'a b' '\"qu'\\''ot'\\''es\"' '\"quot\"' '\\'");
+  }
+}


### PR DESCRIPTION
This adds printing the information from the Action and ActionResult protos. For printing actions, the Command and input roots are grabbed from cache and displayed in human readable format alongside the contents of the Action proto. Similarly, output directories in the given ActionResult are listed recursively.