### PR TITLE
First version for printing out log file

### DIFF
--- a/src/main/java/com/google/devtools/build/remote/client/BUILD
+++ b/src/main/java/com/google/devtools/build/remote/client/BUILD
@@ -22,6 +22,7 @@ java_library(
         "//3rdparty/jvm/io/grpc:grpc_protobuf",
         "//3rdparty/jvm/io/grpc:grpc_stub",
         "//3rdparty/jvm/io/netty:netty_handler",
+        "//src/main/proto:remote_execution_log_java_proto",
         "@googleapis//:google_bytestream_bytestream_java_grpc",
         "@googleapis//:google_bytestream_bytestream_java_proto",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_grpc",

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
@@ -180,6 +180,23 @@ public final class RemoteClientOptions {
     public boolean showRawOutputs = false;
   }
 
+  @Parameters(
+      commandDescription =
+          "Write all log entries from a Bazel gRPC log to standard output. The Bazel gRPC log "
+              + "consists of a sequence of delimited serialized LogEntry protobufs, as produced by "
+              + "the method LogEntry.writeDelimitedTo(OutputStream).",
+      separators = "="
+  )
+  public static class PrintLogCommand {
+    @Parameter(
+        names = { "--file", "-f" },
+        required = true,
+        converter = FileConverter.class,
+        description = "Path to log file."
+    )
+    public File file = null;
+  }
+
   /** Converter for hex_hash/size_bytes string to a Digest object. */
   public static class DigestConverter implements IStringConverter<Digest> {
     @Override

--- a/src/main/proto/BUILD
+++ b/src/main/proto/BUILD
@@ -7,6 +7,7 @@ proto_library(
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_proto",
         "@googleapis//:google_longrunning_operations_proto",
         "@googleapis//:google_rpc_status_proto",
+        "@googleapis//:google_watch_v1_proto",
     ],
 )
 

--- a/src/main/proto/BUILD
+++ b/src/main/proto/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "remote_execution_log_proto",
+    srcs = ["remote_execution_log.proto"],
+    deps = [
+        "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_proto",
+        "@googleapis//:google_longrunning_operations_proto",
+        "@googleapis//:google_rpc_status_proto",
+    ],
+)
+
+java_proto_library(
+    name = "remote_execution_log_java_proto",
+    deps = [":remote_execution_log_proto"],
+)

--- a/src/main/proto/remote_execution_log.proto
+++ b/src/main/proto/remote_execution_log.proto
@@ -1,0 +1,57 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package remote_logging;
+
+import "google/devtools/remoteexecution/v1test/remote_execution.proto";
+import "google/longrunning/operations.proto";
+import "google/rpc/status.proto";
+
+option java_package = "com.google.devtools.build.lib.remote.logging";
+
+// A single log entry for gRPC calls related to remote execution.
+message LogEntry {
+  // Request metadata included in call.
+  google.devtools.remoteexecution.v1test.RequestMetadata metadata = 1;
+
+  // Status of the call on close.
+  google.rpc.Status status = 2;
+
+  // Full method name of the method called as returned from
+  // io.grpc.MethodDescriptor.getFullMethodName() (i.e. in format
+  // $FULL_SERVICE_NAME/$METHOD_NAME).
+  string method_name = 3;
+
+  // Method specific details for this call.
+  RpcCallDetails details = 4;
+}
+
+// Details for a call to
+// google.devtools.remoteexecution.v1test.Execution.Execute.
+message ExecuteDetails {
+  // The google.devtools.remoteexecution.v1test.ExecuteRequest sent by the
+  // call.
+  google.devtools.remoteexecution.v1test.ExecuteRequest request = 1;
+  // The google.longrunning.Operation received by the Execute call.
+  google.longrunning.Operation response = 2;
+}
+
+// Contains details for specific types of calls.
+message RpcCallDetails {
+  oneof details {
+    ExecuteDetails execute = 1;
+  }
+}

--- a/src/main/proto/remote_execution_log.proto
+++ b/src/main/proto/remote_execution_log.proto
@@ -16,9 +16,11 @@ syntax = "proto3";
 
 package remote_logging;
 
+import "google/bytestream/bytestream.proto";
 import "google/devtools/remoteexecution/v1test/remote_execution.proto";
 import "google/longrunning/operations.proto";
 import "google/rpc/status.proto";
+import "google/watcher/v1/watch.proto";
 
 option java_package = "com.google.devtools.build.lib.remote.logging";
 
@@ -45,13 +47,82 @@ message ExecuteDetails {
   // The google.devtools.remoteexecution.v1test.ExecuteRequest sent by the
   // call.
   google.devtools.remoteexecution.v1test.ExecuteRequest request = 1;
+
   // The google.longrunning.Operation received by the Execute call.
   google.longrunning.Operation response = 2;
+}
+
+// Details for a call to
+// google.devtools.remoteexecution.v1test.ActionCache.GetActionResult.
+message GetActionResultDetails {
+  // The google.devtools.remoteexecution.v1test.GetActionResultRequest sent by
+  // the call.
+  google.devtools.remoteexecution.v1test.GetActionResultRequest request = 1;
+
+  // The received google.devtools.remoteexecution.v1test.ActionResult.
+  google.devtools.remoteexecution.v1test.ActionResult response = 2;
+}
+
+// Details for a call to google.watcher.v1.Watch.
+message WatchDetails {
+  // The google.watcher.v1.Request sent by the Watch call.
+  google.watcher.v1.Request request = 1;
+
+  // Each google.watcher.v1.ChangeBatch response received from the
+  // Watch call in order.
+  repeated google.watcher.v1.ChangeBatch responses = 2;
+}
+
+// Details for a call to
+// google.devtools.remoteexecution.v1test.ContentAddressableStorage.FindMissingBlobs.
+message FindMissingBlobsDetails {
+  // The google.devtools.remoteexecution.v1test.FindMissingBlobsRequest request
+  // sent.
+  google.devtools.remoteexecution.v1test.FindMissingBlobsRequest request = 1;
+
+  // The google.devtools.remoteexecution.v1test.FindMissingBlobsResponse
+  // received.
+  google.devtools.remoteexecution.v1test.FindMissingBlobsResponse response = 2;
+}
+
+// Details for a call to google.bytestream.Read.
+message ReadDetails {
+  // The google.bytestream.ReadRequest sent.
+  google.bytestream.ReadRequest request = 1;
+
+  // The number of reads performed in this call.
+  int64 num_reads = 2;
+
+  // The total number of bytes read totalled over all stream responses.
+  int64 bytes_read = 3;
+}
+
+// Details for a call to google.bytestream.Write.
+message WriteDetails {
+  // The names of resources requested to be written to in this call in the order
+  // they were first requested in. If the ByteStream protocol is followed
+  // according to specification, this should only contain have a single element,
+  // which is the resource name specified in the first message of the stream.
+  repeated string resource_names = 1;
+
+  // The number of writes performed in this call.
+  int64 num_writes = 2;
+
+  // The total number of bytes sent over the stream.
+  int64 bytes_sent = 3;
+
+  // The received google.bytestream.WriteResponse.
+  google.bytestream.WriteResponse response = 4;
 }
 
 // Contains details for specific types of calls.
 message RpcCallDetails {
   oneof details {
     ExecuteDetails execute = 1;
+    GetActionResultDetails get_action_result = 2;
+    WatchDetails watch = 3;
+    FindMissingBlobsDetails find_missing_blobs = 4;
+    ReadDetails read = 5;
+    WriteDetails write = 6;
   }
 }


### PR DESCRIPTION
This change adds a command to take a log and print all the entries out in protobuf text format.

For the LogEntry proto, I've just copy and pasted the proto over from Bazel. I've discussed with this Alex, and we couldn't think of any good options for now. For example, importing Bazel WORKSPACE via the git_repository rule adds a 70MB dependency just so we can use the protobufs, though I'm open to doing this too.

Any suggestions are welcome