### PR TITLE
Fix build: Adding missing proto dependency

### DIFF
--- a/src/main/proto/BUILD
+++ b/src/main/proto/BUILD
@@ -4,6 +4,7 @@ proto_library(
     name = "remote_execution_log_proto",
     srcs = ["remote_execution_log.proto"],
     deps = [
+        "@googleapis//:google_bytestream_bytestream_proto",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_proto",
         "@googleapis//:google_longrunning_operations_proto",
         "@googleapis//:google_rpc_status_proto",


### PR DESCRIPTION
I forgot to add this proto dependency so the tool won't build. Somehow I missed this during before merging.