### PR TITLE
Add command for running Actions in Docker container; update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ This tool is built using Bazel:
 ## Usage
 
 The command line options for configuring a connection to a remote cache (cache address,
-authentication, TLS, etc.) with this tool are identical to the options in Bazel. This tool currently
-supports downloading blobs, and recursively listing/downloading directories by digest.
+authentication, TLS, etc.) with this tool are identical to the options in Bazel.
 
-Example for downloading a blob with digest
-762670a6d50679e5495d3a489290bf2b3845172de3c048476668e91f6fc42b8e/18544 to file hello-world:
+For a full listing of configuration options and commands, see `remote_client --help`.
+
+### Downloading cache blobs
+
+This tool can download blobs from a CAS by digest with the `cat` command. For example, to download a
+blob with digest 762670a6d50679e5495d3a489290bf2b3845172de3c048476668e91f6fc42b8e/18544 to the file
+hello-world:
 
     $ bazel-bin/remote_client \
         --remote_cache=localhost:8080 \
@@ -24,8 +28,9 @@ Example for downloading a blob with digest
         --digest=762670a6d50679e5495d3a489290bf2b3845172de3c048476668e91f6fc42b8e/18544 \
         --file=/tmp/hello-world
 
-Example for listing a Directory with digest
-d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
+Given the digest to a Directory which is in CAS, this directory can recursively list the files and
+subdirectories which make up that directory with the `ls` command. For example, to list a Directory
+with digest d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
 
     $ bazel-bin/remote_client \
         --remote_cache=localhost:8080 \
@@ -35,8 +40,8 @@ d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
     examples/cpp [Directory digest: 51f83b4726027e59f982f49ffe5de1828a81e9d2135b379937a26c0840de6b20/175]
     examples/cpp/hello-lib.h [File content digest: fbc71c527a8d91d1b4414484811c20edc0369d0ccdfcfd562ebd01726141bf51/368]
     examples/cpp/hello-world.cc [File content digest: 6cd9f4d242f4441a375539146b0cdabb559c6184921aede45d5a0ed7b84d5253/747]
-    
-Example for downloading a Directory with digest
+
+This Directory can also be downloaded using the `getdir` command:
 d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
 
     $ bazel-bin/remote_client \
@@ -48,8 +53,84 @@ d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
      total 4
      drwxr-xr-x 3 cdlee * 4096 Mar 12 17:22 examples
 
+### <a name="readlog"></a>Printing gRPC log files
 
-For a full listing of configuration options and commands, see `remote_client --help`.
+Bazel can dump a log of remote execution related gRPC calls made during a remote build by
+running the remote build with `--experimental_remote_grpc_log=PATH_TO_LOG` specified. This creates a
+file consisting of serialized log entry protobufs which can be printed by this tool in a
+human-readable way with the `printlog` command:
+
+    $ bazel-bin/remote_client printlog -f PATH_TO_LOG
+
+### Running Actions in Docker
+
+Given an Action in protobuf text format that provides a `container-image` platform, this tool can
+set up its inputs in a local directory and print a Docker command that will run this individual
+action locally in that directory. Action protos in text format can be obtained by [printing a gRPC
+log](#readlog) for a Bazel run that executed that Action remotely and then copying the Action proto
+out of the printed log entry for the Execute call that executed that Action.
+
+The given Action can be inspected with `show_action`:
+
+    $ cat ~/my_action
+    command_digest {
+      hash: "ecd108198bd58dd643b604c55f3d2b1079b1251e68fbed2632c2b8f8afcff7fa"
+      size_bytes: 2113
+    }
+    input_root_digest {
+      hash: "8ecae53041d1be4ca1c65c006f82ec825110741fbf620f5d2bd401d2893029de"
+      size_bytes: 165
+    }
+    output_files: "bazel-out/k8-fastbuild/testlogs/examples/cpp/hello-success_test/test.xml"
+    platform {
+      properties {
+        name: "container-image"
+        value: "gcr.io/cloud-marketplace/google/rbe-debian8@sha256:XXX"
+      }
+    }
+
+    $ bazel-bin/remote_client \
+        --remote_cache=localhost:8080 \
+        show_action \
+        --textproto=~/my_action \
+    Command [digest: ecd108198bd58dd643b604c55f3d2b1079b1251e68fbed2632c2b8f8afcff7fa/2113]:
+    external/bazel_tools/tools/test/test-setup.sh examples/cpp/hello-success_test
+
+    Input files [total: 3, root Directory digest: 8ecae53041d1be4ca1c65c006f82ec825110741fbf620f5d2bd401d2893029de/165]:
+     ... (truncated)
+
+    Output files:
+    bazel-out/k8-fastbuild/testlogs/examples/cpp/hello-success_test/test.xml
+
+    Output directories:
+    (none)
+
+    Platform:
+    properties {
+      name: "container-image"
+      value: "gcr.io/cloud-marketplace/google/rbe-debian8@sha256:XXX"
+    }
+
+Note that this action has a `container-image` platform property which specifies a container that the
+action is to run in.
+
+Using the `run` command, the Action can be setup in a local directory and run with the provided
+Docker command:
+
+    $ bazel-bin/remote_client \
+        --remote_cache=localhost:8080 \
+        run \
+        --textproto=~/my_action \
+        --path=/tmp/run_here
+     Setting up Action in directory /tmp/run_here...
+
+     Successfully setup Action in directory /tmp/run_here.
+
+     To run the Action locally, run:
+       docker run -v /tmp/run_here:/tmp/run_here-docker -w /tmp/run_here-docker -e gcr.io/cloud-marketplace/google/rbe-debian8@sha256:XXX examples/cpp/hello-success_test
+    $ docker run -v /tmp/run_here:/tmp/run_here-docker -w /tmp/run_here-docker -e gcr.io/cloud-marketplace/google/rbe-debian8@sha256:XXX examples/cpp/hello-success_test
+    Hello world
+
 ## Developer Information
 
 ### Third-party Dependencies

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A given Action can be inspected with the `show_action` command:
     $ bazel-bin/remote_client \
         --remote_cache=localhost:8080 \
         show_action \
-        --textproto=~/my_action \
+        --textproto=~/my_action
     Command [digest: ecd108198bd58dd643b604c55f3d2b1079b1251e68fbed2632c2b8f8afcff7fa/2113]:
     external/bazel_tools/tools/test/test-setup.sh examples/cpp/hello-success_test
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ hello-world:
         --digest=762670a6d50679e5495d3a489290bf2b3845172de3c048476668e91f6fc42b8e/18544 \
         --file=/tmp/hello-world
 
-Given the digest to a Directory which is in CAS, this directory can recursively list the files and
+Given the digest to a Directory which is in CAS, this tool can recursively list the files and
 subdirectories which make up that directory with the `ls` command. For example, to list a Directory
 with digest d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
 
@@ -41,7 +41,7 @@ with digest d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
     examples/cpp/hello-lib.h [File content digest: fbc71c527a8d91d1b4414484811c20edc0369d0ccdfcfd562ebd01726141bf51/368]
     examples/cpp/hello-world.cc [File content digest: 6cd9f4d242f4441a375539146b0cdabb559c6184921aede45d5a0ed7b84d5253/747]
 
-This Directory can also be downloaded using the `getdir` command:
+Similarily, a Directory can also be downloaded to a local path using the `getdir` command:
 d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
 
     $ bazel-bin/remote_client \
@@ -56,8 +56,8 @@ d1c2cad73bf385e1ebc7f7433781a9a5807d425de9426c11d770b5123e5c6a5b/82:
 ### <a name="readlog"></a>Printing gRPC log files
 
 Bazel can dump a log of remote execution related gRPC calls made during a remote build by
-running the remote build with `--experimental_remote_grpc_log=PATH_TO_LOG` specified. This creates a
-file consisting of serialized log entry protobufs which can be printed by this tool in a
+running the remote build with the `--experimental_remote_grpc_log=PATH_TO_LOG` flag specified. This
+creates a file consisting of serialized log entry protobufs which can be printed by this tool in a
 human-readable way with the `printlog` command:
 
     $ bazel-bin/remote_client printlog -f PATH_TO_LOG
@@ -70,7 +70,7 @@ action locally in that directory. Action protos in text format can be obtained b
 log](#readlog) for a Bazel run that executed that Action remotely and then copying the Action proto
 out of the printed log entry for the Execute call that executed that Action.
 
-The given Action can be inspected with `show_action`:
+A given Action can be inspected with the `show_action` command:
 
     $ cat ~/my_action
     command_digest {
@@ -114,7 +114,7 @@ The given Action can be inspected with `show_action`:
 Note that this action has a `container-image` platform property which specifies a container that the
 action is to run in.
 
-Using the `run` command, the Action can be setup in a local directory and run with the provided
+Now, using the `run` command, the Action can be setup in a local directory and run with the provided
 Docker command:
 
     $ bazel-bin/remote_client \

--- a/src/main/java/com/google/devtools/build/remote/client/DockerUtil.java
+++ b/src/main/java/com/google/devtools/build/remote/client/DockerUtil.java
@@ -1,9 +1,12 @@
 package com.google.devtools.build.remote.client;
 
+import com.google.common.io.ByteStreams;
 import com.google.devtools.remoteexecution.v1test.Action;
 import com.google.devtools.remoteexecution.v1test.Command;
 import com.google.devtools.remoteexecution.v1test.Command.EnvironmentVariable;
 import com.google.devtools.remoteexecution.v1test.Platform;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -11,6 +14,26 @@ import javax.annotation.Nullable;
 public final class DockerUtil {
   private static final String CONTAINER_IMAGE_ENTRY_NAME = "container-image";
   private static final String DOCKER_IMAGE_PREFIX = "docker://";
+
+  /**
+   * Gets uid of the current user. If the uid could not be fetched, prints a message to stderr and
+   * returns -1.
+   */
+  private static long getUid() {
+    ProcessBuilder processBuilder = new ProcessBuilder();
+    processBuilder.command("id", "-u");
+    try {
+      InputStream stdout = processBuilder.start().getInputStream();
+      byte[] output = ByteStreams.toByteArray(stdout);
+      return Long.parseLong(new String(output).trim());
+    } catch (IOException | NumberFormatException e) {
+      System.err.printf(
+          "Could not fetch UID for passing to Docker container. The provided docker "
+              + "command will not specify a uid (error: %s)\n",
+          e.toString());
+      return -1;
+    }
+  }
 
   /**
    * Checks Action for Docker container definition.
@@ -58,6 +81,13 @@ public final class DockerUtil {
     List<String> commandElements = new ArrayList<>();
     commandElements.add("docker");
     commandElements.add("run");
+
+    long uid = getUid();
+    System.out.println(uid);
+    if (uid >= 0) {
+      commandElements.add("-u");
+      commandElements.add(Long.toString(uid));
+    }
 
     String dockerPathString = workingPath + "-docker";
     commandElements.add("-v");

--- a/src/main/java/com/google/devtools/build/remote/client/DockerUtil.java
+++ b/src/main/java/com/google/devtools/build/remote/client/DockerUtil.java
@@ -38,7 +38,7 @@ public final class DockerUtil {
   /**
    * Checks Action for Docker container definition.
    *
-   * @return The docker container for the Action. If not container could be found, returns null.
+   * @return The docker container for the Action. If no container could be found, returns null.
    */
   private static @Nullable String dockerContainer(Action action) {
     String result = null;
@@ -83,7 +83,6 @@ public final class DockerUtil {
     commandElements.add("run");
 
     long uid = getUid();
-    System.out.println(uid);
     if (uid >= 0) {
       commandElements.add("-u");
       commandElements.add(Long.toString(uid));

--- a/src/main/java/com/google/devtools/build/remote/client/DockerUtil.java
+++ b/src/main/java/com/google/devtools/build/remote/client/DockerUtil.java
@@ -1,0 +1,78 @@
+package com.google.devtools.build.remote.client;
+
+import com.google.devtools.remoteexecution.v1test.Action;
+import com.google.devtools.remoteexecution.v1test.Command;
+import com.google.devtools.remoteexecution.v1test.Command.EnvironmentVariable;
+import com.google.devtools.remoteexecution.v1test.Platform;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public final class DockerUtil {
+  private static final String CONTAINER_IMAGE_ENTRY_NAME = "container-image";
+  private static final String DOCKER_IMAGE_PREFIX = "docker://";
+
+  /**
+   * Checks Action for Docker container definition.
+   *
+   * @return The docker container for the Action. If not container could be found, returns null.
+   */
+  private static @Nullable String dockerContainer(Action action) {
+    String result = null;
+    for (Platform.Property property : action.getPlatform().getPropertiesList()) {
+      if (property.getName().equals(CONTAINER_IMAGE_ENTRY_NAME)) {
+        if (result != null) {
+          // Multiple container name entries
+          throw new IllegalArgumentException(
+              String.format(
+                  "Multiple entries for %s in action.Platform", CONTAINER_IMAGE_ENTRY_NAME));
+        }
+        result = property.getValue();
+        if (!result.startsWith(DOCKER_IMAGE_PREFIX)) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "%s: Docker images must be stored in gcr.io with an image spec in the form "
+                      + "'docker://gcr.io/{IMAGE_NAME}'",
+                  CONTAINER_IMAGE_ENTRY_NAME));
+        }
+        result = result.substring(DOCKER_IMAGE_PREFIX.length());
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Outputs a Docker command that will execute the given action in the given path.
+   *
+   * @param action The Action to be executed in the output docker container command.
+   * @param command The Command of the Action being executed. This must match the Command that is
+   *     referred to from the input parameter Action.
+   * @param workingPath The path that is to be the working directory that the Action is to be
+   *     executed in.
+   */
+  public static String getDockerCommand(Action action, Command command, String workingPath) {
+    String container = dockerContainer(action);
+    if (container == null) {
+      throw new IllegalArgumentException("No docker image specified in given Action.");
+    }
+    List<String> commandElements = new ArrayList<>();
+    commandElements.add("docker");
+    commandElements.add("run");
+
+    String dockerPathString = workingPath + "-docker";
+    commandElements.add("-v");
+    commandElements.add(workingPath + ":" + dockerPathString);
+    commandElements.add("-w");
+    commandElements.add(dockerPathString);
+
+    for (EnvironmentVariable var : command.getEnvironmentVariablesList()) {
+      commandElements.add("-e");
+      commandElements.add(var.getName() + "=" + var.getValue());
+    }
+
+    commandElements.add(container);
+    commandElements.addAll(command.getArgumentsList());
+
+    return ShellEscaper.escapeJoinAll(commandElements);
+  }
+}

--- a/src/main/java/com/google/devtools/build/remote/client/DockerUtil.java
+++ b/src/main/java/com/google/devtools/build/remote/client/DockerUtil.java
@@ -1,3 +1,16 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.devtools.build.remote.client;
 
 import com.google.common.io.ByteStreams;

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClient.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClient.java
@@ -19,8 +19,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.google.common.hash.Hashing;
-import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.LogEntry;
 import com.google.common.io.Files;
+import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.LogEntry;
 import com.google.devtools.build.remote.client.RemoteClientOptions.CatCommand;
 import com.google.devtools.build.remote.client.RemoteClientOptions.GetDirCommand;
 import com.google.devtools.build.remote.client.RemoteClientOptions.GetOutDirCommand;
@@ -62,8 +62,8 @@ public class RemoteClient {
 
   private final AbstractRemoteActionCache cache;
   private final DigestUtil digestUtil;
-  private static final String DELIMETER = "\n---------------------------------------------------------\n";
-
+  private static final String DELIMETER =
+      "\n---------------------------------------------------------\n";
 
   private RemoteClient(AbstractRemoteActionCache cache) {
     this.cache = cache;

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
@@ -197,6 +197,31 @@ public final class RemoteClientOptions {
     public File file = null;
   }
 
+  @Parameters(
+    commandDescription =
+        "Sets up a directory and Docker command to locally run a single action"
+            + "given its Action proto. This requires the Action's inputs to be stored in CAS so that "
+            + "they can be retrieved.",
+    separators = "="
+  )
+  public static class RunCommand {
+    @Parameter(
+      names = {"--textproto", "-p"},
+      required = true,
+      converter = FileConverter.class,
+      description =
+          "Path to the Action proto stored in protobuf text format to be run in the " + "container."
+    )
+    public File file = null;
+
+    @Parameter(
+      names = {"--path", "-o"},
+      converter = PathConverter.class,
+      description = "Path to set up the action inputs in."
+    )
+    public Path path = null;
+  }
+
   /** Converter for hex_hash/size_bytes string to a Digest object. */
   public static class DigestConverter implements IStringConverter<Digest> {
     @Override

--- a/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
+++ b/src/main/java/com/google/devtools/build/remote/client/RemoteClientOptions.java
@@ -181,18 +181,18 @@ public final class RemoteClientOptions {
   }
 
   @Parameters(
-      commandDescription =
-          "Write all log entries from a Bazel gRPC log to standard output. The Bazel gRPC log "
-              + "consists of a sequence of delimited serialized LogEntry protobufs, as produced by "
-              + "the method LogEntry.writeDelimitedTo(OutputStream).",
-      separators = "="
+    commandDescription =
+        "Write all log entries from a Bazel gRPC log to standard output. The Bazel gRPC log "
+            + "consists of a sequence of delimited serialized LogEntry protobufs, as produced by "
+            + "the method LogEntry.writeDelimitedTo(OutputStream).",
+    separators = "="
   )
   public static class PrintLogCommand {
     @Parameter(
-        names = { "--file", "-f" },
-        required = true,
-        converter = FileConverter.class,
-        description = "Path to log file."
+      names = {"--file", "-f"},
+      required = true,
+      converter = FileConverter.class,
+      description = "Path to log file."
     )
     public File file = null;
   }

--- a/src/test/java/com/google/devtools/build/remote/client/BUILD
+++ b/src/test/java/com/google/devtools/build/remote/client/BUILD
@@ -19,7 +19,6 @@ java_test(
         "@googleapis//:google_bytestream_bytestream_java_proto",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_grpc",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_proto",
-        "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_proto",
     ],
 )
 
@@ -27,7 +26,18 @@ java_test(
     name = "ShellEscaperTest",
     srcs = ["ShellEscaperTest.java"],
     deps = [
-        "//src/main/java/com/google/devtools/build/remote/client",
         "//3rdparty/jvm/com/google/truth",
+        "//src/main/java/com/google/devtools/build/remote/client",
+    ],
+)
+
+java_test(
+    name = "DockerUtilTest",
+    srcs = ["DockerUtilTest.java"],
+    deps = [
+        "//3rdparty/jvm/com/google/truth",
+        "//src/main/java/com/google/devtools/build/remote/client",
+        "@com_google_guava_guava//jar",
+        "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/com/google/devtools/build/remote/client/DockerUtilTest.java
+++ b/src/test/java/com/google/devtools/build/remote/client/DockerUtilTest.java
@@ -1,3 +1,16 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.devtools.build.remote.client;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/src/test/java/com/google/devtools/build/remote/client/DockerUtilTest.java
+++ b/src/test/java/com/google/devtools/build/remote/client/DockerUtilTest.java
@@ -1,0 +1,61 @@
+package com.google.devtools.build.remote.client;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.hash.Hashing;
+import com.google.devtools.remoteexecution.v1test.Action;
+import com.google.devtools.remoteexecution.v1test.Command;
+import com.google.devtools.remoteexecution.v1test.Command.EnvironmentVariable;
+import com.google.devtools.remoteexecution.v1test.Platform;
+import com.google.devtools.remoteexecution.v1test.Platform.Property;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link DockerUtil}. */
+@RunWith(JUnit4.class)
+public class DockerUtilTest {
+  private static final DigestUtil DIGEST_UTIL = new DigestUtil(Hashing.sha256());
+
+  @Test
+  public void testGetDockerCommand() {
+    Command command =
+        Command.newBuilder()
+            .addArguments("/bin/echo")
+            .addArguments("hello")
+            .addArguments("escape<'>")
+            .addEnvironmentVariables(
+                EnvironmentVariable.newBuilder().setName("PATH").setValue("/home/test"))
+            .build();
+    Action action =
+        Action.newBuilder()
+            .setCommandDigest(DIGEST_UTIL.compute(command.toByteArray()))
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Property.newBuilder()
+                            .setName("container-image")
+                            .setValue("docker://gcr.io/image")))
+            .build();
+    String commandLine = DockerUtil.getDockerCommand(action, command, "/tmp/test");
+    assertThat(commandLine)
+        .isEqualTo(
+            "docker run -v /tmp/test:/tmp/test-docker -w /tmp/test-docker -e 'PATH=/home/test' "
+                + "gcr.io/image /bin/echo hello 'escape<'\\''>'");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetDockerCommandNoPlatformFail() {
+    Command command =
+        Command.newBuilder()
+            .addArguments("/bin/echo")
+            .addArguments("hello")
+            .addArguments("escape<'>")
+            .addEnvironmentVariables(
+                EnvironmentVariable.newBuilder().setName("PATH").setValue("/home/test"))
+            .build();
+    Action action =
+        Action.newBuilder().setCommandDigest(DIGEST_UTIL.compute(command.toByteArray())).build();
+    DockerUtil.getDockerCommand(action, command, "/tmp/test");
+  }
+}


### PR DESCRIPTION
This adds a command for running Actions that specify a docker container to run in to be run in the specified docker container locally. In particular, the inputs for the action are downloaded from CAS, the output directory structure for the action is created, and a docker command corresponding to the action is printed.

The implementation of this is based on:
https://github.com/bazelbuild/bazel/blob/master/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java#L175

I have a feeling the docker command I generate might be missing some mounts or other flags.